### PR TITLE
Fixa framerate em 60fps

### DIFF
--- a/Assets/Game/Scripts/GameManagement.cs
+++ b/Assets/Game/Scripts/GameManagement.cs
@@ -17,6 +17,7 @@ public class GameManagement : MonoBehaviour{
         DontDestroyOnLoad(this.gameObject);
 
         Instance = this;
+        Application.targetFrameRate = 60;
     }
 
     // Start is called before the first frame update

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -12,6 +12,7 @@
     "com.unity.test-framework": "1.1.33",
     "com.unity.textmeshpro": "3.0.6",
     "com.unity.timeline": "1.7.5",
+    "com.unity.toolchain.linux-x86_64": "2.0.6",
     "com.unity.ugui": "1.0.0",
     "com.unity.visualscripting": "1.8.0",
     "com.unity.modules.ai": "1.0.0",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -254,6 +254,22 @@
         "com.unity.searcher": "4.9.2"
       }
     },
+    "com.unity.sysroot": {
+      "version": "2.0.7",
+      "depth": 1,
+      "source": "registry",
+      "dependencies": {},
+      "url": "https://packages.unity.com"
+    },
+    "com.unity.sysroot.linux-x86_64": {
+      "version": "2.0.6",
+      "depth": 1,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.sysroot": "2.0.7"
+      },
+      "url": "https://packages.unity.com"
+    },
     "com.unity.test-framework": {
       "version": "1.1.33",
       "depth": 0,
@@ -283,6 +299,16 @@
         "com.unity.modules.animation": "1.0.0",
         "com.unity.modules.audio": "1.0.0",
         "com.unity.modules.particlesystem": "1.0.0"
+      },
+      "url": "https://packages.unity.com"
+    },
+    "com.unity.toolchain.linux-x86_64": {
+      "version": "2.0.6",
+      "depth": 0,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.sysroot": "2.0.7",
+        "com.unity.sysroot.linux-x86_64": "2.0.6"
       },
       "url": "https://packages.unity.com"
     },


### PR DESCRIPTION
## Resumo

Este PR ajusta o targetFrameRate do jogo para 60 FPS. A jogabilidade continua normal, porém desta forma nós vamos consumir bem menos bateria e processamento aparelho.

## Antes

![Screenshot from 2023-12-10 13-10-35](https://github.com/tecMTST/imobilidade-urbana/assets/3905582/6bedb16c-c6a3-4752-9260-a0f57a88c811)

## Depois

![Screenshot from 2023-12-10 13-11-56](https://github.com/tecMTST/imobilidade-urbana/assets/3905582/0225a956-a0a8-447d-8c0d-5866e44e0762)


