### PR TITLE
Corrige z-index dos elementos do jogo

### DIFF
--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -56,9 +56,6 @@ TagManager:
   - name: Background
     uniqueID: 3079148925
     locked: 0
-  - name: Player
-    uniqueID: 2631783531
-    locked: 0
   - name: QuestAlert
     uniqueID: 2870207237
     locked: 0
@@ -67,4 +64,7 @@ TagManager:
     locked: 0
   - name: Foreground
     uniqueID: 189734199
+    locked: 0
+  - name: Player
+    uniqueID: 2631783531
     locked: 0


### PR DESCRIPTION
Este PR corrige o z-index do jogador relativo a outros elementos do jogo.

## Antes

Todos NPCs e itens do jogo se sobrepõe à nossa protagonista.

![Screenshot from 2023-12-10 13-36-06](https://github.com/tecMTST/imobilidade-urbana/assets/3905582/3cb01f63-a715-4092-aadc-564690215af2)

![Screenshot from 2023-12-10 13-36-15](https://github.com/tecMTST/imobilidade-urbana/assets/3905582/08242b90-6a07-4eed-b98f-c8835e7b2629)

## Depois

Repare que agora a protagonista permanece no plano principal e todos NPCs e itens ficam no plano de fundo.

![Screenshot from 2023-12-10 13-39-51](https://github.com/tecMTST/imobilidade-urbana/assets/3905582/7ed57755-a16a-4e80-8632-0eed75648c23)

![Screenshot from 2023-12-10 13-39-37](https://github.com/tecMTST/imobilidade-urbana/assets/3905582/f99c1726-f38e-40cf-af80-bd6611d05a13)
