### PR TITLE
fix(colisao) altera forma do colisor da personagem principal

### DIFF
--- a/Assets/Game/Scenes/TrainScene.unity
+++ b/Assets/Game/Scenes/TrainScene.unity
@@ -6178,8 +6178,8 @@ CapsuleCollider2D:
   m_IsTrigger: 0
   m_UsedByEffector: 0
   m_UsedByComposite: 0
-  m_Offset: {x: -0.06083206, y: -0.160787}
-  m_Size: {x: 0.62166405, y: 2.2260745}
+  m_Offset: {x: -0.06083206, y: -0.9629904}
+  m_Size: {x: 0.62166405, y: 0.62166953}
   m_Direction: 0
 --- !u!50 &381227603
 Rigidbody2D:
@@ -34337,7 +34337,7 @@ Transform:
   m_GameObject: {fileID: 1780359269}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -294.6623, y: -0.120179996, z: -8.991622}
+  m_LocalPosition: {x: -295.76, y: -0.12001777, z: -8.991622}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:


### PR DESCRIPTION
Corrige bug #30 

## Detalhes da correção

Reduzi a área de colisão do personagem principal.

A área de colisão antes se expandia pelo personagem por completo, na forma de pílula:

![image](https://github.com/tecMTST/imobilidade-urbana/assets/3905582/f3b6275a-ded5-4b98-b648-75045d8b1d78)

A área de colisão agora está aos pés da personagem principal, e tem formato de círculo:

![image](https://github.com/tecMTST/imobilidade-urbana/assets/3905582/52ea98c1-e7ea-43a3-8fe1-c46cd8dfd444)

## Antes

[Screencast from 12.12.2023 17:36:13.webm](https://github.com/tecMTST/imobilidade-urbana/assets/3905582/dab7f72a-80af-4340-a414-724dac9fb26c)

## Depois

[Screencast from 12.12.2023 17:35:05.webm](https://github.com/tecMTST/imobilidade-urbana/assets/3905582/ba831f81-eaec-47f4-b3bc-4cc0b4c4308d)
